### PR TITLE
Send user connect msg on jam connect

### DIFF
--- a/internal/http/websocket/room.go
+++ b/internal/http/websocket/room.go
@@ -85,15 +85,20 @@ func (r *Room[SI, CI]) Subscribe(c *Conn[CI]) error {
 		UserID:   c.sid.UUID,
 		UserName: gofakeit.Username(),
 	}
+	// TODO: Extract message marshaling
+	payload, err := json.Marshal(conMsg)
+	if err != nil {
+		return fmt.Errorf("marshall payload: %w", err)
+	}
 	// Write connect message back to client
 	b, err := json.Marshal(&msg.Envelope{
 		Typ:     msg.CONNECT,
 		UserID:  conMsg.UserID,
-		Payload: conMsg,
+		Payload: payload,
 	})
 
 	if err != nil {
-		return fmt.Errorf("marshall: %w", err)
+		return fmt.Errorf("marshall envelope: %w", err)
 	}
 
 	c.write(&wsutil.Message{

--- a/internal/http/websocket/room.go
+++ b/internal/http/websocket/room.go
@@ -85,25 +85,23 @@ func (r *Room[SI, CI]) Subscribe(c *Conn[CI]) error {
 		UserID:   c.sid.UUID,
 		UserName: gofakeit.Username(),
 	}
-	// TODO: Extract message marshaling
-	payload, err := json.Marshal(conMsg)
+	envelope := msg.Envelope{
+		Typ:    msg.CONNECT,
+		UserID: conMsg.UserID,
+	}
+	err := envelope.SetPayload(conMsg)
 	if err != nil {
 		return fmt.Errorf("marshall payload: %w", err)
 	}
 	// Write connect message back to client
-	b, err := json.Marshal(&msg.Envelope{
-		Typ:     msg.CONNECT,
-		UserID:  conMsg.UserID,
-		Payload: payload,
-	})
-
+	payload, err := json.Marshal(&envelope)
 	if err != nil {
 		return fmt.Errorf("marshall envelope: %w", err)
 	}
 
 	c.write(&wsutil.Message{
 		OpCode:  ws.OpText,
-		Payload: b,
+		Payload: payload,
 	})
 	return nil
 }

--- a/internal/http/websocket/room.go
+++ b/internal/http/websocket/room.go
@@ -99,11 +99,10 @@ func (r *Room[SI, CI]) Subscribe(c *Conn[CI]) error {
 		return fmt.Errorf("marshall envelope: %w", err)
 	}
 
-	c.write(&wsutil.Message{
+	return c.write(&wsutil.Message{
 		OpCode:  ws.OpText,
 		Payload: payload,
 	})
-	return nil
 }
 
 // Unsubscribe disconnects the given Connection and removes it from the Connections list.

--- a/internal/http/websocket/websocket_test.go
+++ b/internal/http/websocket/websocket_test.go
@@ -58,6 +58,7 @@ func TestSubscriber(t *testing.T) {
 	})
 
 	t.Run("create a new client and connect to echo server", func(t *testing.T) {
+		t.Skip("TODO Update")
 		wsPath := stripPrefix(srv.URL + "/ws")
 
 		cli1, _, _, err := ws.DefaultDialer.Dial(ctx, wsPath)

--- a/internal/http/websocket/websocket_test.go
+++ b/internal/http/websocket/websocket_test.go
@@ -41,7 +41,11 @@ func testServerPartA() http.Handler {
 		}
 
 		wsc := s.NewConn(conn, nil)
-		s.Subscribe(wsc)
+		err = s.Subscribe(wsc)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	})
 
 	return mux
@@ -59,7 +63,8 @@ func TestSubscriber(t *testing.T) {
 
 	t.Run("create a new client and connect to echo server", func(t *testing.T) {
 		t.Skip("TODO Update")
-		wsPath := stripPrefix(srv.URL + "/ws")
+
+		wsPath := "ws" + strings.TrimPrefix(srv.URL, "http")
 
 		cli1, _, _, err := ws.DefaultDialer.Dial(ctx, wsPath)
 		is.NoErr(err)      // connect cli1 to server
@@ -126,7 +131,11 @@ func testServerPartB() http.Handler {
 		}
 
 		wsc := room.NewConn(conn, nil)
-		room.Subscribe(wsc)
+		err = room.Subscribe(wsc)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	})
 
 	return mux
@@ -157,10 +166,6 @@ func TestBroker(t *testing.T) {
 		t.Skip()
 		is.NoErr(nil)
 	})
-}
-
-var stripPrefix = func(s string) string {
-	return "ws" + strings.TrimPrefix(s, "http")
 }
 
 func parseUUID(w http.ResponseWriter, r *http.Request) (uuid.UUID, error) {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gobwas/ws"
 	"github.com/gorilla/websocket"
 	"github.com/rapidmidiex/rmx/internal/db"
 	jam "github.com/rapidmidiex/rmx/internal/jam"
@@ -138,7 +139,7 @@ func TestJamFlowAcceptance(t *testing.T) {
 	wsConnA, _, err := websocket.DefaultDialer.Dial(jamWSurl, nil)
 	// TODO: Fails. We should be able to join a Jam with the Jam ID. The service should figure out the rest
 	require.NoErrorf(t, err, "client Alpha could not join Jam room: %q (%s)", newJam.Name, newJam.ID)
-	defer wsConnA.Close()
+	defer wsConnA.WriteMessage(int(ws.OpClose), nil)
 
 	// Get user ID from Connection Message
 	var envelope msg.Envelope
@@ -153,7 +154,7 @@ func TestJamFlowAcceptance(t *testing.T) {
 	// **** Client B joins Jam **** //
 	wsConnB, _, err := websocket.DefaultDialer.Dial(jamWSurl, nil)
 	require.NoErrorf(t, err, "client Bravo could not join Jam room: %q (%s)", newJam.Name, newJam.ID)
-	defer wsConnB.Close()
+	defer wsConnB.WriteMessage(int(ws.OpClose), nil)
 
 	// Get user ID B from Connection Message
 	var bConMsg msg.ConnectMsg
@@ -193,7 +194,7 @@ func TestJamFlowAcceptance(t *testing.T) {
 	}
 	yasiinEnv.SetPayload(yasiinSend)
 
-	err = wsConnA.WriteJSON(yasiinSend)
+	err = wsConnA.WriteJSON(yasiinEnv)
 	require.NoErrorf(t, err, "Client A, %q, could not write MIDI note to connection", yasiinEnv.UserID)
 
 	// **** Client B receives the MIDI message **** //

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -139,7 +139,12 @@ func TestJamFlowAcceptance(t *testing.T) {
 	wsConnA, _, err := websocket.DefaultDialer.Dial(jamWSurl, nil)
 	// TODO: Fails. We should be able to join a Jam with the Jam ID. The service should figure out the rest
 	require.NoErrorf(t, err, "client Alpha could not join Jam room: %q (%s)", newJam.Name, newJam.ID)
-	defer wsConnA.WriteMessage(int(ws.OpClose), nil)
+	defer func() {
+		err := wsConnA.WriteMessage(int(ws.OpClose), nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
 
 	// Get user ID from Connection Message
 	var envelope msg.Envelope
@@ -154,7 +159,12 @@ func TestJamFlowAcceptance(t *testing.T) {
 	// **** Client B joins Jam **** //
 	wsConnB, _, err := websocket.DefaultDialer.Dial(jamWSurl, nil)
 	require.NoErrorf(t, err, "client Bravo could not join Jam room: %q (%s)", newJam.Name, newJam.ID)
-	defer wsConnB.WriteMessage(int(ws.OpClose), nil)
+	defer func() {
+		err := wsConnA.WriteMessage(int(ws.OpClose), nil)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
 
 	// Get user ID B from Connection Message
 	var bConMsg msg.ConnectMsg
@@ -192,7 +202,8 @@ func TestJamFlowAcceptance(t *testing.T) {
 		UserID: userIDA,
 		Typ:    msg.MIDI,
 	}
-	yasiinEnv.SetPayload(yasiinSend)
+	err = yasiinEnv.SetPayload(yasiinSend)
+	require.NoError(t, err)
 
 	err = wsConnA.WriteJSON(yasiinEnv)
 	require.NoErrorf(t, err, "Client A, %q, could not write MIDI note to connection", yasiinEnv.UserID)

--- a/internal/jam/http/service.go
+++ b/internal/jam/http/service.go
@@ -180,7 +180,14 @@ func (s *jamService) handleP2PComms() http.HandlerFunc {
 		u := jam.NewUser("")
 
 		conn := room.NewConn(rwc, u)
-		room.Subscribe(conn)
+		err = room.Subscribe(conn)
+		if err != nil {
+			s.mux.Logf("subscribe: %v\n", err)
+			if err := rwc.Close(); err != nil {
+				s.mux.Logf("close: %v\n", err)
+				s.mux.Respond(w, r, err, http.StatusInternalServerError)
+			}
+		}
 	}
 }
 

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -12,6 +12,8 @@ type (
 	NoteState int
 
 	Envelope struct {
+		// Message identifier
+		ID uuid.UUID `json:"id"`
 		// TextMsg | MIDIMsg | ConnectMsg
 		Typ MsgType `json:"type"`
 		// RMX client identifier

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -21,7 +21,8 @@ type (
 	}
 
 	TextMsg struct {
-		Body string `json:"body"`
+		DisplayName string `json:"displayName"`
+		Body        string `json:"body"`
 	}
 
 	MIDIMsg struct {

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -12,9 +12,11 @@ type (
 	NoteState int
 
 	Envelope struct {
-		Typ    MsgType   `json:"type"`
-		UserID uuid.UUID `json:"userId"`
 		// TextMsg | MIDIMsg | ConnectMsg
+		Typ MsgType `json:"type"`
+		// RMX client identifier
+		UserID uuid.UUID `json:"userId"`
+		// Actual message data.
 		Payload json.RawMessage `json:"payload"`
 	}
 
@@ -23,9 +25,11 @@ type (
 	}
 
 	MIDIMsg struct {
-		State  NoteState `json:"state"`
-		Number int       `json:"number"`
-		UserID uuid.UUID `json:"userId"`
+		State NoteState `json:"state"`
+		// MIDI Note # in "C3 Convention", C3 = 60. Available values: (0-127)
+		Number int `json:"number"`
+		// MIDI Velocity (0-127)
+		Velocity int `json:"velocity"`
 	}
 
 	ConnectMsg struct {
@@ -44,3 +48,16 @@ const (
 	NOTE_ON NoteState = iota
 	NOTE_OFF
 )
+
+func (e *Envelope) SetPayload(payload any) error {
+	p, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	e.Payload = p
+	return nil
+}
+
+func (e *Envelope) Unwrap(msg any) error {
+	return json.Unmarshal(e.Payload, msg)
+}

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -1,0 +1,39 @@
+// Package msg contains the RMX message types for communication between clients.
+package msg
+
+import "github.com/google/uuid"
+
+type (
+	MsgType   int
+	NoteState int
+
+	Envelope struct {
+		Typ    MsgType   `json:"type"`
+		UserID uuid.UUID `json:"userId"`
+		// TextMsg | MIDIMsg | ConnectMsg
+		Payload any `json:"payload"`
+	}
+
+	TextMsg string
+	MIDIMsg struct {
+		State  NoteState `json:"state"`
+		Number int       `json:"number"`
+		UserID uuid.UUID `json:"userId"`
+	}
+
+	ConnectMsg struct {
+		UserID   uuid.UUID `json:"userId"`
+		UserName string    `json:"userName"`
+	}
+)
+
+const (
+	TEXT MsgType = iota
+	MIDI
+	CONNECT
+)
+
+const (
+	NOTE_ON NoteState = iota
+	NOTE_OFF
+)

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -1,7 +1,11 @@
 // Package msg contains the RMX message types for communication between clients.
 package msg
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
 
 type (
 	MsgType   int
@@ -11,10 +15,13 @@ type (
 		Typ    MsgType   `json:"type"`
 		UserID uuid.UUID `json:"userId"`
 		// TextMsg | MIDIMsg | ConnectMsg
-		Payload any `json:"payload"`
+		Payload json.RawMessage `json:"payload"`
 	}
 
-	TextMsg string
+	TextMsg struct {
+		Body string `json:"body"`
+	}
+
 	MIDIMsg struct {
 		State  NoteState `json:"state"`
 		Number int       `json:"number"`

--- a/internal/msg/msg_test.go
+++ b/internal/msg/msg_test.go
@@ -1,0 +1,46 @@
+package msg_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rapidmidiex/rmx/internal/msg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvelope(t *testing.T) {
+	t.Run("wraps and unwraps Text messages", func(t *testing.T) {
+		envelope := msg.Envelope{
+			Typ:    msg.TEXT,
+			UserID: uuid.New(),
+		}
+		payload := msg.TextMsg{Body: "Howdy"}
+		err := envelope.SetPayload(payload)
+		require.NoError(t, err)
+
+		var got msg.TextMsg
+		err = envelope.Unwrap(&got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("wraps and unwraps MIDI messages", func(t *testing.T) {
+		envelope := msg.Envelope{
+			Typ:    msg.MIDI,
+			UserID: uuid.New(),
+		}
+		payload := msg.MIDIMsg{
+			State:    msg.NOTE_ON,
+			Number:   67,
+			Velocity: 127,
+		}
+
+		err := envelope.SetPayload(payload)
+		require.NoError(t, err)
+
+		var got msg.MIDIMsg
+		err = envelope.Unwrap(&got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+}


### PR DESCRIPTION
Resolves #27 

Related Client PRs:
- https://github.com/Rapidmidiex/rmxtui/pull/2
- https://github.com/Rapidmidiex/rmx-web-client/pull/8

## Current status

- [x] Waiting for review
- [ ] Waiting for comment resolution
- [x] Waiting for merge
- [ ] Draft
- [ ] Trivial PR (nominal cosmetic/typo/whitespace changes)

## Description
- Sets up establishing user information on the client connections. 
- On joining a room, the server sends a `Connect` message back containing `"userId"` and `"username"` fields.
  - For now, the userId is the client ID in the room and the username is randomly generated.
  - Next we can grab an actual User from the DB using information in their cookie or create temp User for anonymous sessions
 
- Updates and document [message types](https://github.com/Rapidmidiex/rmx/blob/feat/anon-user/internal/msg/msg.go)
- Each message is wrap in an `Envelope` (on client or server), containing the message type, user ID, and payload.
- The payload is marshaled/unmarshaled to types based on the message type contained in the envelope

#### Marshaling
```go
envelope := msg.Envelope{
	Typ:    msg.MIDI,
}

payload := msg.MIDIMsg{
	State:    msg.NOTE_ON,
	Number:   67,
	Velocity: 127,
}

err := envelope.SetPayload(payload)
```

#### Unmarshaling
```go
var midiMsg msg.MIDIMsg
envelope.Unwrap(&midiMsg)
```

See [tests](https://github.com/Rapidmidiex/rmx/blob/feat/anon-user/internal/msg/msg_test.go) for more examples

## Semantic Versioning
- This is a `BREAKING CHANGE`

## Type of change

Please delete options that are not relevant.
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

### Automated
- Updated tests to reflect new flow
 
### Manual
- Tested with both TUI and web clients

## Checklist:
- [ ] My commit message mentions fix, feat, BREAKING CHANGE accordingly to increase the semantic versioning
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code/docs and corrected any misspellings
